### PR TITLE
Another mass migration

### DIFF
--- a/database/migrations/2020_10_01_054922_create_task_statuses_table.php
+++ b/database/migrations/2020_10_01_054922_create_task_statuses_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskStatusesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_statuses');
+    }
+}

--- a/database/migrations/2020_10_01_054947_create_task_priorities_table.php
+++ b/database/migrations/2020_10_01_054947_create_task_priorities_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskPrioritiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_priorities', function (Blueprint $table) {
+            $table->id();
+            $table->string('priority');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_priorities');
+    }
+}

--- a/database/migrations/2020_10_01_055003_create_task_creation_types_table.php
+++ b/database/migrations/2020_10_01_055003_create_task_creation_types_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskCreationTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_creation_types', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_creation_types');
+    }
+}

--- a/database/migrations/2020_10_01_055546_create_tasks_table.php
+++ b/database/migrations/2020_10_01_055546_create_tasks_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('owner_id')
+                ->references('id')
+                ->on('users')
+                ->nullable();
+            $table->unsignedInteger('author_id')
+                ->references('id')
+                ->on('users')
+                ->nullable();
+            $table->unsignedInteger('status_id')
+                ->references('id')
+                ->on('task_statuses')
+                ->default(1);
+            $table->unsignedInteger('priority_id')
+                ->references('id')
+                ->on('task_priorities')
+                ->default(1);
+            $table->unsignedInteger('source_id')
+                ->references('id')
+                ->on('task_creation_types')
+                ->default(1);
+            $table->string('title');
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tasks');
+    }
+}

--- a/database/migrations/2020_10_01_055547_create_task_changes_table.php
+++ b/database/migrations/2020_10_01_055547_create_task_changes_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskChangesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_changes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id')
+                ->references('id')
+                ->on('users');
+            $table->unsignedInteger('task_id')
+                ->references('id')
+                ->on('tasks');
+            $table->string('field');
+            $table->string('old_value');
+            $table->string('new_value');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_changes');
+    }
+}

--- a/database/migrations/2020_10_01_060134_create_task_subscribers_table.php
+++ b/database/migrations/2020_10_01_060134_create_task_subscribers_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskSubscribersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_subscribers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('task_id')
+                ->references('id')
+                ->on('tasks');
+            $table->unsignedInteger('user_id')
+                ->references('id')
+                ->on('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_subscribers');
+    }
+}

--- a/database/migrations/2020_10_01_060152_create_task_relations_table.php
+++ b/database/migrations/2020_10_01_060152_create_task_relations_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskRelationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_relations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('task_id')
+                ->references('id')
+                ->on('tasks');
+            $table->unsignedInteger('parent_id')
+                ->references('id')
+                ->on('tasks')
+                ->nullabl();
+            $table->unsignedInteger('child_id')
+                ->references('id')
+                ->on('tasks')
+                ->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_relations');
+    }
+}

--- a/database/migrations/2020_10_01_060217_create_task_links_table.php
+++ b/database/migrations/2020_10_01_060217_create_task_links_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskLinksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_links', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('task_id')
+                ->references('id')
+                ->on('tasks');
+            $table->string('link');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_links');
+    }
+}

--- a/database/migrations/2020_10_01_060224_create_task_comments_table.php
+++ b/database/migrations/2020_10_01_060224_create_task_comments_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTaskCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('task_comments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('task_id')
+                ->references('id')
+                ->on('tasks');
+            $table->unsignedInteger('author_id')
+                ->references('id')
+                ->on('users');
+            $table->string('comment');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('task_comments');
+    }
+}


### PR DESCRIPTION
```
$php artisan migrate                                                                                                                                                                                               joshglass@devbox
Migrating: 2020_10_01_054922_create_task_statuses_table
Migrated:  2020_10_01_054922_create_task_statuses_table (19.46ms)
Migrating: 2020_10_01_054947_create_task_priorities_table
Migrated:  2020_10_01_054947_create_task_priorities_table (7.30ms)
Migrating: 2020_10_01_055003_create_task_creation_types_table
Migrated:  2020_10_01_055003_create_task_creation_types_table (7.04ms)
Migrating: 2020_10_01_055546_create_tasks_table
Migrated:  2020_10_01_055546_create_tasks_table (6.42ms)
Migrating: 2020_10_01_055547_create_task_changes_table
Migrated:  2020_10_01_055547_create_task_changes_table (7.16ms)
Migrating: 2020_10_01_060134_create_task_subscribers_table
Migrated:  2020_10_01_060134_create_task_subscribers_table (8.02ms)
Migrating: 2020_10_01_060152_create_task_relations_table
Migrated:  2020_10_01_060152_create_task_relations_table (9.00ms)
Migrating: 2020_10_01_060217_create_task_links_table
Migrated:  2020_10_01_060217_create_task_links_table (8.94ms)
Migrating: 2020_10_01_060224_create_task_comments_table
Migrated:  2020_10_01_060224_create_task_comments_table (10.32ms)
```