### PR TITLE
Small Update to Task Ownership UI

### DIFF
--- a/resources/js/Pages/Tasks/Task.vue
+++ b/resources/js/Pages/Tasks/Task.vue
@@ -95,7 +95,9 @@
         <p><b>Created:</b> {{ new Date(task.created_at).toLocaleDateString() }}</p>
       </section>
       <section class='grid-col-3 mb-4'>
+        <p v-if='task.owner_id'><b>Owner:</b> {{ task.owner.name }}</p>
         <Select
+          v-else
           :options='users'
           wrapClasses='w-100'
           placeholder='e.g. John Doe'


### PR DESCRIPTION
- only use select when a task doesn't have an owner yet
- will add multi-owner logic and UI in future diff